### PR TITLE
Changing joypad input

### DIFF
--- a/src/SoraVoice.cpp
+++ b/src/SoraVoice.cpp
@@ -441,7 +441,7 @@ void FPSPatches( int limit )
 
 void SoraVoice::JoypadInput(DIJOYSTATE* joypadState)
 {
-	if ( (joypadState->lZ >= (32768 + 100) || joypadState->lZ <= (32768 - 100)) || (Config.TurboJoypadButton > 0 && joypadState->rgbButtons[Config.TurboJoypadButton - 1]))
+	if ((Config.TurboJoypadButton > 0 && joypadState->rgbButtons[Config.TurboJoypadButton - 1]))
 	{
 		joypadTurbo = true;
 	}


### PR DESCRIPTION
Removing some conditions to leave only the button that is selected to activate turbo on the joypad. Otherwise it feels awkward as if it just activates randomly