### PR TITLE
Allow trigger buttons for turbo via ed_voice.ini option

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -128,6 +128,7 @@ bool CConfig::LoadConfig(const char * configFn, bool create)
 
 	GET_VALUE(TurboMultiplier, kv);
 	GET_VALUE_MAXFIX(TurboJoypadButton, kv);
+	GET_VALUE(TurboJoypadTriggers, kv);
 	GET_VALUE_MAXFIX(TurboKeyboardKey, kv);
 	GET_VALUE(FPSTarget, kv);
 
@@ -169,6 +170,7 @@ bool CConfig::SaveConfig(const char * configFn) const
 	OUTPUT_VALUE(DisableDududu, ofs);
 	OUTPUT_VALUE(TurboMultiplier, ofs);
 	OUTPUT_VALUE(TurboJoypadButton, ofs);
+	OUTPUT_VALUE(TurboJoypadTriggers, ofs);
 	OUTPUT_VALUE(TurboKeyboardKey, ofs);
 	OUTPUT_VALUE(FPSTarget, ofs);
 	OUTPUT_VALUE(ShowInfo, ofs);
@@ -213,6 +215,7 @@ void CConfig::load_default(bool all)
 
 	SET_DEFAULT(TurboMultiplier);
 	SET_DEFAULT(TurboJoypadButton);
+	SET_DEFAULT(TurboJoypadTriggers);
 	SET_DEFAULT(TurboKeyboardKey);
 	SET_DEFAULT(FPSTarget);
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -46,6 +46,7 @@ struct CConfig
 	DEFINE_CONFIG(DisableDududu, 1);
 	DEFINE_CONFIG(TurboMultiplier, 2);
 	DEFINE_CONFIG_WMAX(TurboJoypadButton, 0, 32);
+	DEFINE_CONFIG(TurboJoypadTriggers, 1);
 	DEFINE_CONFIG_WMAX(TurboKeyboardKey, DIK_LCONTROL, DIK_MEDIASELECT);
 	DEFINE_CONFIG(FPSTarget, 60);
 	DEFINE_CONFIG_WMAX(ShowInfo, ShowInfo_On, 2);

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -100,6 +100,7 @@ bool CMessage::LoadMessage(const char * resName)
 	SET_MESSAGE(top, AutoPlayAll);
 	SET_MESSAGE(top, TurboMultiplier);
 	SET_MESSAGE(top, TurboJoypadButton);
+	SET_MESSAGE(top, TurboJoypadTriggers);	
 	SET_MESSAGE(top, TurboKeyboardKey);
 	SET_MESSAGE(top, FPSTarget);
 	SET_MESSAGE(top, ShowInfo);
@@ -123,6 +124,7 @@ bool CMessage::LoadMessage(const char * resName)
 	SET_MESSAGE_CMT(top, DisableDududu);
 	SET_MESSAGE_CMT(top, TurboMultiplier);
 	SET_MESSAGE_CMT(top, TurboJoypadButton);
+	SET_MESSAGE_CMT(top, TurboJoypadTriggers);
 	SET_MESSAGE_CMT(top, TurboKeyboardKey);
 	SET_MESSAGE_CMT(top, FPSTarget);
 	SET_MESSAGE_CMT(top, ShowInfo);

--- a/src/Message.h
+++ b/src/Message.h
@@ -32,6 +32,8 @@ struct CMessage {
 	const char * TurboMultiplier;
 
 	const char * TurboJoypadButton;
+  
+	const char * TurboJoypadTriggers;
 
 	const char * TurboKeyboardKey;
 
@@ -67,6 +69,8 @@ struct CMessage {
 		const char * TurboMultiplier;
 
 		const char * TurboJoypadButton;
+
+		const char * TurboJoypadTriggers;
 
 		const char * TurboKeyboardKey;
 

--- a/src/RC/files/Message_en.ini
+++ b/src/RC/files/Message_en.ini
@@ -42,6 +42,8 @@ TurboMultiplier="Turbo multiplier: x"
 
 TurboJoypadButton="Turbo Joypad button: "
 
+TurboJoypadTriggers="Turbo Joypad trigger: "
+
 TurboKeyboardKey="Turbo keyboard key: "
 
 FPSTarget="FPS Target: "
@@ -75,6 +77,8 @@ CMT_DisableDududu=#Disable texts' SE for voiced dialogs. Default is 1(Enable).
 CMT_TurboMultiplier=#Multiplier for Turbo mode. Default is 2.
 
 CMT_TurboJoypadButton=#Optional joypad button for Turbo mode. Default is 0 (none)
+
+CMT_TurboJoypadTriggers=#Enables turbo by pressing joypad LT or RT triggers. Default is 1 (Enable)
 
 CMT_TurboKeyboardKey=#Keyboard key for Turbo mode. Default is 29 (Left control)\nFor a list of key codes for each key to use with this setting see here: https://gist.github.com/AGraber/0c13cabb63c175530501e78fb1675da3
 

--- a/src/RC/files/Message_en.ini
+++ b/src/RC/files/Message_en.ini
@@ -42,7 +42,7 @@ TurboMultiplier="Turbo multiplier: x"
 
 TurboJoypadButton="Turbo Joypad button: "
 
-TurboJoypadTriggers="Turbo Joypad trigger: "
+TurboJoypadTriggers="Turbo Joypad triggers: "
 
 TurboKeyboardKey="Turbo keyboard key: "
 

--- a/src/RC/files/Message_zh.ini
+++ b/src/RC/files/Message_zh.ini
@@ -42,6 +42,8 @@ TurboMultiplier="Turbo multiplier: x"
 
 TurboJoypadButton="Turbo Joypad button: "
 
+TurboJoypadTriggers="Turbo Joypad triggers: "
+
 TurboKeyboardKey="Turbo keyboard key: "
 
 FPSTarget="FPS Target: "
@@ -75,6 +77,8 @@ CMT_DisableDududu=#在语音播放时，禁用文字显示的嘟嘟声。默认�
 CMT_TurboMultiplier=#Multiplier for Turbo mode. Default is 2.
 
 CMT_TurboJoypadButton=#Optional joypad button for Turbo mode. Default is 0 (none)
+
+CMT_TurboJoypadTriggers=#Enables turbo by pressing joypad LT or RT triggers. Default is 1 (Enable)
 
 CMT_TurboKeyboardKey=#Keyboard key for Turbo mode. Default is 29 (Left control)\nFor a list of key codes for each key to use with this setting see here: https://gist.github.com/AGraber/0c13cabb63c175530501e78fb1675da3
 

--- a/src/SoraVoice.cpp
+++ b/src/SoraVoice.cpp
@@ -441,7 +441,7 @@ void FPSPatches( int limit )
 
 void SoraVoice::JoypadInput(DIJOYSTATE* joypadState)
 {
-	if ((Config.TurboJoypadButton > 0 && joypadState->rgbButtons[Config.TurboJoypadButton - 1]))
+	if ((Config.TurboJoypadTriggers > 0 && (joypadState->lZ >= (32768 + 100) || joypadState->lZ <= (32768 - 100))) || (Config.TurboJoypadButton > 0 && joypadState->rgbButtons[Config.TurboJoypadButton - 1]))
 	{
 		joypadTurbo = true;
 	}


### PR DESCRIPTION
Never made a pull request before, so no idea if this is going to work. 

Basically the idea is to allow the trigger buttons to enable turbo if it is set in the ini. Many users have become used to triggers enabling turbo by default, so it is enabled in the ini by default. But users have also had issues with turbo either always being on or off due to their controllers floating (I think), so it's also nice to have an option to disable the triggers altogether.